### PR TITLE
Upgrade to JUnit 4.11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,10 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [environ "0.3.0"]
-                 [junit "4.10"]
+                 [junit "4.11"]
                  [clj-http "0.5.2"]
                  [midje "1.4.0"]
-                 [com.github.rest-driver/rest-client-driver "1.1.28" :exclusions [org.slf4j/slf4j-nop]]]
+                 [com.github.rest-driver/rest-client-driver "1.1.29" :exclusions [org.slf4j/slf4j-nop]]]
 
   :profiles {:dev {:plugins [[lein-rpm "0.0.4"]
                              [lein-midje "2.0.0-SNAPSHOT"]]}})

--- a/test/rest_cljer/test/core.clj
+++ b/test/rest_cljer/test/core.clj
@@ -1,0 +1,21 @@
+(ns rest-cljer.test.core
+  (:require [rest-cljer.core :refer [rest-driven]]
+            [midje.sweet :refer :all]
+            [clj-http.client :refer [post]]
+            [environ.core :refer [env]])
+  (:import [com.github.restdriver.clientdriver ClientDriver]))
+
+(fact "expected rest-driven call succeeds without exceptions"
+      (let [restdriver-port (ClientDriver/getFreePort)
+            resource-path "/some/resource/path"
+            url (str "http://localhost:" restdriver-port resource-path)]
+        (alter-var-root (var env) assoc :restdriver-port restdriver-port)
+        (rest-driven [{:method :POST, :url resource-path}
+                      {:status 204}]
+                     (post url) => (contains {:status 204}))))
+
+(fact "unexpected rest-driven call should fail with exception"
+      (let [restdriver-port (ClientDriver/getFreePort)
+            url (str "http://localhost:" restdriver-port)]
+        (alter-var-root (var env) assoc :restdriver-port restdriver-port)
+        (rest-driven [] (post url))) => (throws RuntimeException))


### PR DESCRIPTION
Fix a conflict with Hamcrest matcher classes that was previously fixed
by classpath ordering. This brings JUnit's Hamcrest dependency up to
version 1.3, which is _more_ compatible with rest-driver and its
dependencies.

Also added some basic midje facts to sanity check rest-cljer, run them
with: `lein midje`.
