### PR TITLE
Add ability to supply a post processing function using :and

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,18 @@ Request map params:
     :method -> :GET :POST :PUT :DELETE :TRACE :HEAD :OPTIONS
     :body   -> a string or regex or map that should match the body of the request
     :url    -> a string or regex that should match the url
+    :and    -> a function that will recieve a ClientDriverRequest and can apply
+               additional rest-driver setup steps that aren't explicitly supported
+               by rest-cljer.
 
 Response map params:
 
     :type   -> :JSON (application/json) :XML (text/xml) :PLAIN (text/plain)
     :status -> the response status as a number
     :body   -> a response body (string)
-
+    :and    -> a function that will recieve a ClientDriverResponse and can apply
+               additional rest-driver setup steps that aren't explicitly supported
+               by rest-cljer.
 
 ## License
 

--- a/src/rest_cljer/core.clj
+++ b/src/rest_cljer/core.clj
@@ -74,6 +74,9 @@
                                       (withStatus (:status response#))
                                       (withContentType (content-type (:type response#))))]
 
+              (when (fn? (:and request#)) ((:and request#) on-request#))
+              (when (fn? (:and response#)) ((:and response#) give-response#))
+
               (add-params on-request# (:params request#))
               (add-body   on-request# (:body   request#))
 


### PR DESCRIPTION
Allows direct access to the rest-drive ClientRequest and ClientResponse for manual setup steps that are not provided explicitly by rest-cljer.

Critique welcome :)
