### PR TITLE
Add support for request & response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,24 +80,28 @@ There is also some sweetening of response definitions, like so:
 
 Request map params:
 
-    :method -> :GET :POST :PUT :DELETE :TRACE :HEAD :OPTIONS
-    :body   -> a string or regex or map that should match the body of the request
-    :url    -> a string or regex that should match the url
-    :and    -> a function that will recieve a ClientDriverRequest and can apply
-               additional rest-driver setup steps that aren't explicitly supported
-               by rest-cljer.
+    :method  -> :GET :POST :PUT :DELETE :TRACE :HEAD :OPTIONS
+    :body    -> a string or regex or map that should match the body of the request
+    :url     -> a string or regex that should match the url
+    :headers -> a map of headers that are expected on the incoming request (where
+                key is header name and value is header value).
+    :and     -> a function that will recieve a ClientDriverRequest and can apply
+                additional rest-driver setup steps that aren't explicitly supported
+                by rest-cljer.
 
 Response map params:
 
-    :type   -> :JSON (application/json) :XML (text/xml) :PLAIN (text/plain)
-    :status -> the response status as a number
-    :body   -> a response body (string)
-    :and    -> a function that will recieve a ClientDriverResponse and can apply
-               additional rest-driver setup steps that aren't explicitly supported
-               by rest-cljer.
-    :times  -> for repeating responses, the number of times a matching request will 
-               be given this response (use :times :any to use this response for an 
-               unlimited number of matching requests).
+    :type    -> :JSON (application/json) :XML (text/xml) :PLAIN (text/plain)
+    :status  -> the response status as a number
+    :body    -> a response body (string)
+    :headers -> a map of headers that will be added to the response (where key is
+                header name and value is header value).
+    :and     -> a function that will recieve a ClientDriverResponse and can apply
+                additional rest-driver setup steps that aren't explicitly supported
+                by rest-cljer.
+    :times   -> for repeating responses, the number of times a matching request will
+                be given this response (use :times :any to use this response for an
+                unlimited number of matching requests).
 
 ## License
 

--- a/src/rest_cljer/core.clj
+++ b/src/rest_cljer/core.clj
@@ -60,6 +60,13 @@
   (cond (= :any times) (.anyTimes expectation)
         times (.times expectation times)))
 
+(defn add-header! [r [k v]]
+  (.withHeader r k v))
+
+(defn add-headers [r headers]
+  (doseq [h headers]
+    (add-header! r h)))
+
 (defn sweeten-response [r]
   (if (map? (:body r))
     (assoc r :body (json-str (:body r)) :type :JSON :status 200)
@@ -78,11 +85,13 @@
                                       (withStatus (:status response#))
                                       (withContentType (content-type (:type response#))))]
 
+              (add-params  on-request# (:params  request#))
+              (add-body    on-request# (:body    request#))
+              (add-headers on-request# (:headers request#))
+
               (when (fn? (:and request#)) ((:and request#) on-request#))
               (when (fn? (:and response#)) ((:and response#) give-response#))
-
-              (add-params on-request# (:params request#))
-              (add-body   on-request# (:body   request#))
+              (add-headers give-response# (:headers response#))
 
               (let [expectation# (.addExpectation driver# on-request# give-response#)]
                 (add-times expectation# (:times response#)))))

--- a/test/rest_cljer/test/core.clj
+++ b/test/rest_cljer/test/core.clj
@@ -83,3 +83,33 @@
                      (post url)
                      (post url)
                      (post url))) => (throws RuntimeException))
+
+(fact "rest-driven call with expected header succeeds without exceptions"
+      (let [restdriver-port (ClientDriver/getFreePort)
+            resource-path "/some/resource/path"
+            url (str "http://localhost:" restdriver-port resource-path)]
+        (alter-var-root (var env) assoc :restdriver-port restdriver-port)
+        (rest-driven [{:method :POST, :url resource-path, :headers {"from" "midjefact", "with" "value"}}
+                      {:status 204}]
+                     (post url {:headers {"from" "midjefact", "with" "value"}}) => (contains {:status 204}))))
+
+(fact "rest-driven call with missing header throws exception"
+      (let [restdriver-port (ClientDriver/getFreePort)
+            resource-path "/some/resource/path"
+            url (str "http://localhost:" restdriver-port resource-path)]
+        (alter-var-root (var env) assoc :restdriver-port restdriver-port)
+        (rest-driven [{:method :POST, :url resource-path, :headers {"From" "origin"}}
+                      {:status 204}]
+                     (post url) => (contains {:status 204}))) => (throws RuntimeException))
+
+(fact "rest-driven call with response headers succeeds without exceptions"
+      (let [restdriver-port (ClientDriver/getFreePort)
+            resource-path "/some/resource/path"
+            url (str "http://localhost:" restdriver-port resource-path)]
+        (alter-var-root (var env) assoc :restdriver-port restdriver-port)
+        (rest-driven [{:method :POST, :url resource-path}
+                      {:status 204, :headers {"from" "rest-cljer", "with" "value"}}]
+                     (let [response (post url)]
+                       response => (contains {:status 204})
+                       (:headers response) => (contains {"from" "rest-cljer"})
+                       (:headers response) => (contains {"with" "value"})))))


### PR DESCRIPTION
Supports matching headers on an incoming request and including headers
in the client driver response.
