### PR TITLE
Correct project name in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# clj-driver
+# rest-cljer
 
 A Clojure wrapper for [rest-driver](https://github.com/rest-driver/rest-driver).
 


### PR DESCRIPTION
Just noticed this on the homepage.
