### PR TITLE
fixed issue with sweetening override status code

### DIFF
--- a/src/rest_cljer/core.clj
+++ b/src/rest_cljer/core.clj
@@ -67,9 +67,10 @@
   (doseq [h headers]
     (add-header! r h)))
 
-(defn sweeten-response [r]
+(defn sweeten-response [{:keys [status] :or {status 200} :as r} ]
+  (println "Status" status "\n" r)
   (if (map? (:body r))
-    (assoc r :body (json-str (:body r)) :type :JSON :status 200)
+    (assoc r :body (json-str (:body r)) :type :JSON :status status)
     r))
 
 (defmacro rest-driven

--- a/test/rest_cljer/test/core.clj
+++ b/test/rest_cljer/test/core.clj
@@ -45,6 +45,19 @@
                        (:headers resp) => (contains {"content-type" "application/json"})
                        (read-str (:body resp) :key-fn keyword) => {:inigo "montoya"}))))
 
+(fact "sweetening of response definitions doesn't override explicit value"
+      (let [restdriver-port (ClientDriver/getFreePort)
+            resource-path "/some/resource/path"
+            url (str "http://localhost:" restdriver-port resource-path)]
+        (alter-var-root (var env) assoc :restdriver-port restdriver-port)
+        (rest-driven [{:method :GET :url resource-path}
+                      {:status 400
+                       :body {:inigo "montoya"}}]
+                     (let [resp (http/get url {:throw-exceptions false})]
+                       resp => (contains {:status 400})
+                       (:headers resp) => (contains {"content-type" "application/json"})
+                       (read-str (:body resp) :key-fn keyword) => {:inigo "montoya"}))))
+
 (fact "test post-processing of request and response, replace initial values with new ones using :and function"
       (let [restdriver-port (ClientDriver/getFreePort)
             resource-path "/some/resource/path"


### PR DESCRIPTION
If the expected response look like below the status returned by rest-driver is 200. I added some code to make 200 default value if status is not specified otherwise use status code.

{:status 400
:body {:id 123}}
