### PR TITLE
Allow pairs as nested vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ Another example:
              response => (contains {:status 202}))))
 ```
 
+Each pair may be enclosed in a vector if you like:
+
+```clj
+(fact "Expectations as nested vectors"
+       (rest-driven
+           [[{:method :GET :url "/events"} {:type :JSON :status 200}]
+            [{:method :GET :url "/events"} {:type :JSON :status 201}]]
+
+             (client/get url) => (contains {:status 200})
+             (client/get url) => (contains {:status 201})))
+```
+
 You can also specific a map as the body of the request, thereby asserting that the right content is sent:
 
 ```clj

--- a/src/rest_cljer/core.clj
+++ b/src/rest_cljer/core.clj
@@ -90,7 +90,7 @@
   ([pairs & body]
      `(let [driver# (.. (ClientDriverFactory.) (createClientDriver (Integer. (env :restdriver-port))))]
         (try
-          (doseq [pair# (partition 2 ~pairs)]
+          (doseq [pair# (partition 2 (flatten ~pairs))]
             (let [request# (first pair#)
                   response# (sweeten-response (second pair#))
                   on-request#    (.. (RestClientDriver/onRequestTo (:url request#))

--- a/test/rest_cljer/test/core.clj
+++ b/test/rest_cljer/test/core.clj
@@ -162,7 +162,17 @@
             resource-path "/some/resource/path"
             url (str "http://localhost:" restdriver-port resource-path)]
         (alter-var-root (var env) assoc :restdriver-port restdriver-port)
-        (rest-driven [{:url resource-path :params :any}
+        (rest-driven [{:url resource-path}
                       {:status 200}]
                      (let [response (get url)]
                        response => (contains {:status 200})))))
+
+(fact "request/response can be paired as a vector"
+      (let [restdriver-port (ClientDriver/getFreePort)
+            resource-path "/some/resource/path"
+            url (str "http://localhost:" restdriver-port resource-path)]
+        (alter-var-root (var env) assoc :restdriver-port restdriver-port)
+        (rest-driven [[{:url resource-path} {:status 201}]
+                      [{:url resource-path} {:status 202}]]
+                     (get url) => (contains {:status 201})
+                     (get url) => (contains {:status 202}))))


### PR DESCRIPTION
This should help keep larger lists of expectations neat, since it's possible to do something along the lines of:

``` clj
(rest-driven [(expect-create-foo)
              (expect-query-bar)
              (expect-update-baz)]
             ...)
```
