### PR TITLE
Allow more unusual HTTP Methods to be specified.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 .lein-repl-history
 *.iml
 .idea
+.nrepl-port

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ There is also some sweetening of response definitions, like so:
 
 Request map params:
 
-    :method  -> :GET :POST :PUT :DELETE :TRACE :HEAD :OPTIONS (defaults to :GET if not supplied)
+    :method  -> :GET :POST :PUT :DELETE :TRACE :HEAD :OPTIONS or a more unusual method as a string,
+                for example "PATCH", "PROPFIND" (defaults to :GET if not supplied)
     :params  -> a map of expected request params in the form {"name" "value"} or {:name "value"}
                 that would match ?name=value
                 alternatively use :any to match any params

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [clj-http "0.5.2"]
                  [midje "1.5.1"]
                  [org.clojure/data.json "0.2.1"]
-                 [com.github.rest-driver/rest-client-driver "1.1.36" :exclusions [org.slf4j/slf4j-nop]]]
+                 [com.github.rest-driver/rest-client-driver "1.1.42" :exclusions [org.slf4j/slf4j-nop]]]
 
   :lein-release {:deploy-via :clojars}
 

--- a/src/rest_cljer/core.clj
+++ b/src/rest_cljer/core.clj
@@ -93,6 +93,11 @@
         b (RestClientDriver/giveResponse b)
         :else (RestClientDriver/giveEmptyResponse)))
 
+(defn choose-method [{method :method}]
+  (if (string? method)
+    (ClientDriverRequest$Method/custom method)
+    ((or method :GET) verbs)))
+
 (defmacro rest-driven
   ([pairs & body]
      `(let [driver# (.. (ClientDriverFactory.) (createClientDriver (Integer. (env :restdriver-port))))]
@@ -101,7 +106,7 @@
             (let [request# (first pair#)
                   response# (sweeten-response (second pair#))
                   on-request#    (.. (RestClientDriver/onRequestTo (:url request#))
-                                      (withMethod ((:method request# :GET) verbs)))
+                                     (withMethod (choose-method request#)))
                   give-response# (.. (create-response (:body response#) (content-type (:type response#)))
                                       (withStatus (:status response#)))]
 

--- a/test/rest_cljer/test/core.clj
+++ b/test/rest_cljer/test/core.clj
@@ -1,7 +1,7 @@
 (ns rest-cljer.test.core
   (:require [rest-cljer.core :refer [rest-driven]]
             [midje.sweet :refer :all]
-            [clj-http.client :as http :refer [post put get]]
+            [clj-http.client :as http :refer [post put get patch]]
             [environ.core :refer [env]]
             [clojure.data.json :refer [json-str read-str]])
   (:import [com.github.restdriver.clientdriver ClientDriver ClientDriverRequest$Method]))
@@ -194,3 +194,12 @@
                       [{:url resource-path} {:status 202}]]
                      (get url) => (contains {:status 201})
                      (get url) => (contains {:status 202}))))
+
+(fact "expected rest-driven call with an unusual HTTP method succeeds"
+      (let [restdriver-port (ClientDriver/getFreePort)
+            resource-path "/some/resource/path"
+            url (str "http://localhost:" restdriver-port resource-path)]
+        (alter-var-root (var env) assoc :restdriver-port restdriver-port)
+        (rest-driven [{:method "PATCH", :url resource-path}
+                      {:status 204}]
+                     (patch url) => (contains {:status 204}))))


### PR DESCRIPTION
References and uses updated rest-driver.  Uses Method.custom() to allow unusual http methods to be specified  in a mocked request.
