### PR TITLE
Added ability to capture request body as a string for later inspection.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pom.xml.asc
 *.iml
 .idea
 .nrepl-port
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ The body can also be a regex or a string along with a content type, specified as
         :body [#"a regex" "someothercontent/type"]
 ```
 
+If you need to inspect the details of a request you can create a string-capture and analyse the details later:
+
+```clj
+(fact "I want to capture the body of a request for further inspection"
+      (let [capturer (string-capture)]
+        (rest-driven [{:method :POST :url resource-path
+                       :body ["somethingstrange" "text/plain"]
+                       :capture capturer}
+                      {:status 204}]
+                     (post url {:content-type "text/plain"
+                                :body "somethingstrange"
+                                :throw-exceptions false}) => (contains {:status 204})
+                     (.getContent capturer) => "somethingstrange")))
+```
+
 There is also some sweetening of response definitions, like so:
 
 ```clj
@@ -110,6 +125,8 @@ Request map params:
     :url     -> a string or regex that should match the url
     :headers -> a map of headers that are expected on the incoming request (where
                 key is header name and value is header value).
+    :capture -> an instance created using the string-capture function which captures the body
+                of the request as a string for later inspection using .getContent.
     :and     -> a function that will receive a ClientDriverRequest and can apply
                 additional rest-driver setup steps that aren't explicitly supported
                 by rest-cljer.

--- a/src/rest_cljer/core.clj
+++ b/src/rest_cljer/core.clj
@@ -41,6 +41,9 @@
         (doto description
           (.appendText (str "expected has <" (first difs) ">, actual has <" (second difs) ">")))))))
 
+(defn string-capture []
+  (proxy [com.github.restdriver.clientdriver.capture.StringBodyCapture] []))
+
 (defn add-param! [request param-name param-vals]
   (doseq [v param-vals]
     (.withParam request (name param-name) v)))
@@ -75,6 +78,9 @@
 (defn add-absent-headers [r headers]
   (doseq [h headers]
     (add-absent-header! r h)))
+
+(defn add-capture [r c]
+  (.capturingBodyIn r c))
 
 (defn sweeten-response [{:keys [status] :or {status 200} :as r} ]
   (if (map? (:body r))
@@ -114,6 +120,7 @@
               (add-body    on-request# (:body    request#))
               (add-headers on-request# (:headers request#))
               (add-absent-headers on-request# (:headers (:not request#)))
+              (add-capture on-request# (:capture request#))
 
               (when (fn? (:and request#)) ((:and request#) on-request#))
               (when (fn? (:and response#)) ((:and response#) give-response#))


### PR DESCRIPTION
I wanted to be able to capture the body of a request as a string for a situation where the body is rather complex and I need to inspect its details.  Does this suit?  I'm not convinced that there isn't a better way than this so interested to see what you think? 