### PR TITLE
Improvement to absent headers checking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ Request map params:
     :body    -> a map that should match the body of the request or a vector containing a string or regex
                 plus the content type.
     :url     -> a string or regex that should match the url
-    :headers -> a map of headers that are expected on the incoming request (where
-                key is header name and value is header value).
+    :headers -> a map of headers that are expected on the incoming request where
+                keys are header names and values are header values.
     :capture -> an instance created using the string-capture function which captures the body
                 of the request as a string for later inspection.
     :and     -> a function that will receive a ClientDriverRequest and can apply
@@ -132,6 +132,9 @@ Request map params:
                 by rest-cljer.
     :not     -> a map of request params that will NOT appear in the request. Currently
                 only :headers is supported (i.e. to match against a header NOT appearing in the request).
+                :headers should be specified as a vector of strings, although a deprecated approach is
+                to specify a map where keys are header names and values are header values (which can be 
+                any value).
 
 Response map params:
 

--- a/src/rest_cljer/core.clj
+++ b/src/rest_cljer/core.clj
@@ -74,12 +74,18 @@
   (doseq [h headers]
     (add-header! r h)))
 
-(defn add-absent-header! [r [k v]]
+(defn add-absent-header! [r k]
   (.withoutHeader r k))
 
 (defn add-absent-headers [r headers]
-  (doseq [h headers]
-    (add-absent-header! r h)))
+  "Add headers that shouldn't be present. The original approach was to add them as a map. However,
+   the value of each header is irrelevant and, so, a second approach of specifying just the names
+   of the headers as a vector has been added. The first apprach is retained for back compatibility."
+  (if (map? headers)
+    (doseq [h headers]
+      (add-absent-header! r (first h)))
+    (doseq [h headers]
+      (add-absent-header! r h))))
 
 (defn add-capture [r c]
   (.capturingBodyIn r c))

--- a/test/rest_cljer/test/core.clj
+++ b/test/rest_cljer/test/core.clj
@@ -173,6 +173,24 @@
                       {:status 204}]
                      (http/post url {:headers {"myheader" "myvalue"}}) => (contains {:status 204}))) => (throws RuntimeException))
 
+(fact "rest-driven call without headers that are expected to be absent (specified in a vector) succeeds without exceptions"
+      (let [restdriver-port (ClientDriver/getFreePort)
+            resource-path "/some/resource/path"
+            url (str "http://localhost:" restdriver-port resource-path)]
+        (alter-var-root (var env) assoc :restdriver-port restdriver-port)
+        (rest-driven [{:method :POST, :url resource-path, :not {:headers ["myheader"]}}
+                      {:status 204}]
+                     (http/post url) => (contains {:status 204}))))
+
+(fact "rest-driven call with headers that are expected to be absent (specified in a vector) throws exception"
+      (let [restdriver-port (ClientDriver/getFreePort)
+            resource-path "/some/resource/path"
+            url (str "http://localhost:" restdriver-port resource-path)]
+        (alter-var-root (var env) assoc :restdriver-port restdriver-port)
+        (rest-driven [{:method :POST, :url resource-path, :not {:headers ["myheader"]}}
+                      {:status 204}]
+                     (http/post url {:headers {"myheader" "myvalue"}}) => (contains {:status 204}))) => (throws RuntimeException))
+
 (fact "rest-driven call with response headers succeeds without exceptions"
       (let [restdriver-port (ClientDriver/getFreePort)
             resource-path "/some/resource/path"


### PR DESCRIPTION
Hi Ben,

Do you think this small change makes sense?  I think it makes more sense to add 'absent' headers as a list of values rather than as a map as the header values are ignored. I've retained backwards compatibility as you will see.