### PR TITLE
Removing midje dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,6 @@
                  [com.github.rest-driver/rest-client-driver "1.1.42" :exclusions [org.slf4j/slf4j-nop]]
                  [environ "0.3.0"]
                  [junit "4.11"]
-                 [midje "1.5.1"]
                  [org.clojure/clojure "1.4.0"]
                  [speclj "3.1.0"]]
 
@@ -17,4 +16,5 @@
 
   :profiles {:dev {:plugins [[lein-midje "3.1.0"]
                              [lein-release "1.0.5"]
-                             [lein-rpm "0.0.4"]]}})
+                             [lein-rpm "0.0.4"]]
+                   :dependencies [[midje "1.5.1"]]}})

--- a/src/rest_cljer/core.clj
+++ b/src/rest_cljer/core.clj
@@ -2,8 +2,7 @@
   (:require [cheshire.core :as json]
             [clojure.data :refer [diff]]
             [clojure.java.io :refer [input-stream]]
-            [environ.core :refer [env]]
-            [midje.sweet :refer :all])
+            [environ.core :refer [env]])
   (:import [com.github.restdriver.clientdriver ClientDriverFactory ClientDriverRule
             RestClientDriver ClientDriverRequest$Method]
            [com.github.restdriver.clientdriver.capture StringBodyCapture]
@@ -146,6 +145,6 @@
 
           ~@body
 
-          (try (.verify driver#) (catch Exception e# (fact e# => nil)))
+          (.verify driver#)
 
           (finally (.shutdownQuietly driver#))))))


### PR DESCRIPTION
Hey Ben,

I'm not sure how backwards incompatible this would make rest-cljer but still passes all the existing tests.

At the moment it just throws the exceptions up raw for the user to expect, catch, test etc.

What do you think?
