### PR TITLE
Add cider indent metadata for rest-driven macro

### DIFF
--- a/src/rest_cljer/core.clj
+++ b/src/rest_cljer/core.clj
@@ -118,6 +118,7 @@
     ((or method :GET) verbs)))
 
 (defmacro rest-driven
+  {:style/indent 1}
   ([pairs & body]
      `(let [driver# (.. (ClientDriverFactory.) (createClientDriver (Integer. (env :restdriver-port))))]
         (try


### PR DESCRIPTION
See http://cider.readthedocs.io/en/latest/indent_spec/