### PR TITLE
Use Integer/valueOf instead of Integer.

### DIFF
--- a/src/rest_cljer/core.clj
+++ b/src/rest_cljer/core.clj
@@ -135,7 +135,7 @@
 (defmacro rest-driven
   {:style/indent 1}
   ([pairs & body]
-     `(let [driver# (.. (ClientDriverFactory.) (createClientDriver (Integer. (env :restdriver-port))))]
+     `(let [driver# (.. (ClientDriverFactory.) (createClientDriver (Integer/valueOf (env :restdriver-port))))]
         (try
           (doseq [pair# (partition 2 (flatten ~pairs))]
             (let [request# (first pair#)


### PR DESCRIPTION
as it is deprecated in Java… 1.9 (and this messed with our linting process).